### PR TITLE
Ignore unknown JSON properties for futures accounts

### DIFF
--- a/src/main/java/com/stableapps/bookmapadapter/model/FutureAccountsContractFixedMargin.java
+++ b/src/main/java/com/stableapps/bookmapadapter/model/FutureAccountsContractFixedMargin.java
@@ -1,10 +1,12 @@
 package com.stableapps.bookmapadapter.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FutureAccountsContractFixedMargin {
 
     @JsonProperty("available_qty")
@@ -21,5 +23,4 @@ public class FutureAccountsContractFixedMargin {
     double realizedPnl;
     @JsonProperty("unrealized_pnl")
     double unrealizedPnl;
-        
 }


### PR DESCRIPTION
OKEx added some additional fields, which currently makes parsing the JSON throw an exception, since unknown fields aren't ignored.